### PR TITLE
Remove max-width constraint from layout containers

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -43,7 +43,7 @@ const Footer = () => {
 
   return (
     <footer className=" text-white ">
-      <div className="max-w-7xl mx-auto px-6 py-8 border-t border-white/20">
+      <div className=" mx-auto px-6 py-8 border-t border-white/20">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="space-y-4">
             <div className="flex items-center space-x-2">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@ import React from "react";
 function Header() {
   return (
     <header>
-      <div className="bg-transparent border-b border-white/10 max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
+      <div className="bg-transparent border-b border-white/10  mx-auto px-6 py-4 flex items-center justify-between">
         <div className="flex items-center space-x-2">
           <Image
             src="/assets/img/acadxp-logo.png"


### PR DESCRIPTION
Eliminated the 'max-w-7xl' class from Footer and Header container divs to allow full-width layouts. This change improves layout flexibility and consistency across the site.