### PR TITLE
Update auth client to use public env variable

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,5 +1,5 @@
 import { createAuthClient } from "better-auth/react";
 export const authClient = createAuthClient({
   // baseURL: "http://localhost:8000/api/v1/auth",
-  baseURL: process.env.NEXT_BETTER_AUTH_BASE_URL,
+  baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_BASE_URL!,
 });


### PR DESCRIPTION
Changed the baseURL to use NEXT_PUBLIC_BETTER_AUTH_BASE_URL for compatibility with Next.js public environment variables.